### PR TITLE
Fixed links to cluster setup README in multi-cluster-ingress recipes

### DIFF
--- a/multi-cluster-ingress/multi-cluster-blue-green-cluster/README.md
+++ b/multi-cluster-ingress/multi-cluster-blue-green-cluster/README.md
@@ -122,7 +122,7 @@ Now that you have the background knowledge and understanding of MCI, you can try
     - app.yaml is the manifest for the `default-backend` Deployment. This manifest should be deployed on both clusters.
     - ingress.yaml is the manifest for the MultiClusterIngress and MultiClusterService resources. These will be deployed only on the `gke-1` cluster as this was set as the config cluster and is the  cluster that the MCI controlller is listening to for updates.
 
-4. Separately log in to each cluster and deploy the app.yaml manifest. You can configure these contexts as shown [here](../cluster-setup.md).
+4. Separately log in to each cluster and deploy the app.yaml manifest. You can configure these contexts as shown [here](../../cluster-setup.md).
 
     ```sh
     $ kubectl --context=gke-1 apply -f app.yaml

--- a/multi-cluster-ingress/multi-cluster-ingress-basic/README.md
+++ b/multi-cluster-ingress/multi-cluster-ingress-basic/README.md
@@ -117,7 +117,7 @@ Now that you have the background knowledge and understanding of MCI, you can try
     $ cd gke-networking-recipes/multi-cluster-ingress/multi-cluster-ingress-basic
     ```
 
-2. Deploy the two clusters `gke-1` and `gke-2` as specified in [cluster setup](../cluster-setup.md)
+2. Deploy the two clusters `gke-1` and `gke-2` as specified in [cluster setup](../../cluster-setup.md)
 
 3. Now follow the steps for cluster registration with Hub and enablement of Multi-cluster Ingress.
 
@@ -126,7 +126,7 @@ Now that you have the background knowledge and understanding of MCI, you can try
     - app.yaml is the manifest for the foo and bar Deployments. This manifest should be deployed on both clusters.
     - ingress.yaml is the manifest for the MultiClusterIngress and MultiClusterService resources. These will be deployed only on the `gke-1` cluster as this was set as the config cluster and is the  cluster that the MCI controlller is listening to for updates.
 
-4. Separately log in to each cluster and deploy the app.yaml manifest. You can configure these contexts as shown [here](../cluster-setup.md).
+4. Separately log in to each cluster and deploy the app.yaml manifest. You can configure these contexts as shown [here](../../cluster-setup.md).
 
     ```sh
     $ kubectl --context=gke-1 apply -f app.yaml


### PR DESCRIPTION
While browsing multi cluster ingress examples I've found broken links to "cluster setup" README