### PR TITLE
Adding recipe for ingress-nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ GKE is a managed Kubernetes platform that provides a more opinionated and seamle
   - [Secure Ingress](./ingress/single-cluster/ingress-https) - Secure Ingress-hosted Services with HTTPS, Google-managed certificates, SSL policies, and HTTPS redirects.
   - [IAP Ingress](./ingress/single-cluster/ingress-iap) - GKE Ingress with Identity-Aware Proxy based authentication.
   - [CloudArmor Ingress](./ingress/single-cluster/ingress-cloudarmor) - GKE Ingress with Google CloudArmor policy protection.
+  - [Nginx Ingress](./ingress/single-cluster/ingress-nginx) - Deploy an internet-facing HTTP load balancer with Nginx Ingress. 
   - [Custom HTTP health check Ingress](./ingress/single-cluster/ingress-custom-http-health-check) - GKE Ingress with custom HTTP based health check.
   - [Custom gRPC health check Ingress](./ingress/single-cluster/ingress-custom-grpc-health-check) - GKE Ingress with custom gRPC based health check.
 

--- a/ingress/single-cluster/ingress-nginx/README.md
+++ b/ingress/single-cluster/ingress-nginx/README.md
@@ -54,8 +54,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: foo
-  annotations:
-    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
   - port: 80

--- a/ingress/single-cluster/ingress-nginx/README.md
+++ b/ingress/single-cluster/ingress-nginx/README.md
@@ -1,0 +1,138 @@
+
+# GKE Ingress + NGNIX Ingress
+
+GKE allows customers to deploy their own Ingress Controllers instead of the standard GCP offering. NGNIX is a popular option because of it's simplicity and open source nature. This example deploys an application on GKE and exposes the application with an NGNIX controller. See the [ingress-ngnix.yaml](ingress-ngnix.yaml) manifest for full deployment spec. 
+
+### Use-cases
+
+- Load Balance Websocket and HTTPS applications
+- Rewrite request URIs before sending it to an application
+
+### Relevant documentation
+
+- [Ingress for GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress)
+- [Ingress with NGINX](https://cloud.google.com/community/tutorials/nginx-ingress-gke)
+- [NGNIX on GKE](https://kubernetes.github.io/ingress-nginx/deploy/#gce-gke)
+
+### Versions
+
+- 1.16.5-gke.1 and later.
+
+
+
+### Networking Manifests
+
+In this example an internal Ingress resource matches for HTTP traffic with `foo.example.com`  for path `/foo`  and sends it to the `foo` Service at port 8080. A public IP address is automatically provisioned by the Ngnix controller which listens for traffic on port 8080. The Ingress resource below shows that there is one host match. Any traffic which does not match this is sent to the default backend to provide 404 responses.
+
+
+```yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: foo-external
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+  - host: foo.example.com
+    http:
+      paths:
+      - pathType: Prefix
+          path: "/foo"
+          backend:
+            serviceName: foo
+            servicePort: 8080
+```
+
+The following `foo` Service selects across the Pods from the `foo` Deployment. This Deployment consists of three Pods which will get load balanced across. Note the use of the `cloud.google.com/neg: '{"ingress": true}'` annotation. This enables container native load balancing which is a best practice. In GKE 1.17+ this is annotated by default.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    name: http
+  selector:
+    app: foo
+  type: ClusterIP
+```
+
+### Try it out
+
+1. Download this repo and navigate to this folder
+
+```sh
+$ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
+Cloning into 'gke-networking-recipes'...
+
+$ cd gke-networking-recipes/ingress/ingress-ngnix.yaml
+```
+2. Ensure that your user has cluster-admin permissions on the cluster. This can be done with the following command:
+
+```
+kubectl create clusterrolebinding cluster-admin-binding \
+  --clusterrole cluster-admin \
+  --user $(gcloud config get-value account)
+```
+3. Install the ingress controller 
+
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.0/deploy/static/provider/cloud/deploy.yaml
+```
+
+4. Deploy the Ingress, Deployment, and Service resources in the [ingress-ngnix.yaml](ingress-ngnix.yaml) manifest.
+
+```sh
+$ kubectl apply -f ingress-ngnix.yaml
+ingress.networking.k8s.io/ingress-resource created
+service/foo created
+deployment.apps/foo created
+
+```
+
+
+5. It will take up to a minute for the Pods to deploy and up to a few minutes for the Ingress resource to be ready. Validate their progress and make sure that no errors are surfaced in the resource events.
+
+
+```
+$ kubectl get deploy foo
+NAME   READY   UP-TO-DATE   AVAILABLE   AGE
+foo    3/3     3            3           2m56s
+
+$ kubectl describe ingress ingress-resource
+Name:             ingress-resource
+Namespace:        default
+Address:          34.102.236.246
+Default backend:  default-http-backend:80 (10.96.0.5:8080)
+Rules:
+  Host             Path  Backends
+  ----             ----  --------
+  foo.example.com
+                   /foo   foo:8080 (10.96.1.3:8080,10.96.1.4:8080,10.96.2.5:8080)
+Annotations:       kubernetes.io/ingress.class: nginx
+                   nginx.ingress.kubernetes.io/ssl-redirect: false
+Events:            <none>
+```
+
+Please note in the event logs that some firewall rules should be manually configured for health checks.
+
+6. Finally, we can validate the data plane by sending traffic to our Ingress VIP
+
+```sh
+
+$ curl -H "host: foo.example.com" 34.102.236.246
+
+```
+
+### Cleanup
+
+```sh
+kubectl delete -f ingress-ngnix.yaml
+```

--- a/ingress/single-cluster/ingress-nginx/README.md
+++ b/ingress/single-cluster/ingress-nginx/README.md
@@ -26,7 +26,7 @@ In this example an internal Ingress resource matches for HTTP traffic with `foo.
 
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion:  networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo-external
@@ -38,14 +38,16 @@ spec:
   - host: foo.example.com
     http:
       paths:
-      - pathType: Prefix
-          path: "/foo"
-          backend:
-            serviceName: foo
-            servicePort: 8080
+      - path: /foo
+        pathType: Prefix
+        backend:
+          service:
+            name: foo
+            port:
+              number: 8080
 ```
 
-The following `foo` Service selects across the Pods from the `foo` Deployment. This Deployment consists of three Pods which will get load balanced across. Note the use of the `cloud.google.com/neg: '{"ingress": true}'` annotation. This enables container native load balancing which is a best practice. In GKE 1.17+ this is annotated by default.
+The following `foo` Service selects across the Pods from the `foo` Deployment. This Deployment consists of three Pods which will get load balanced across.
 
 ```yaml
 apiVersion: v1
@@ -127,7 +129,7 @@ Please note in the event logs that some firewall rules should be manually config
 
 ```sh
 
-$ curl -H "host: foo.example.com" 34.102.236.246
+$ curl -H "host: foo.example.com" 34.102.236.246 /foo
 
 ```
 

--- a/ingress/single-cluster/ingress-nginx/ingress-nginx.yaml
+++ b/ingress/single-cluster/ingress-nginx/ingress-nginx.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion:  networking.k8s.io/v1beta1 
+apiVersion:  networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo-external
@@ -23,17 +23,18 @@ spec:
   - host: foo.example.com
     http:
       paths:
-      - path: "/foo"
+      - path: /foo
+        pathType: Prefix
         backend:
-          serviceName: foo
-          servicePort: 8080
+          service:
+            name: foo
+            port:
+              number: 8080
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: foo
-  annotations:
-    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
   - port: 8080

--- a/ingress/single-cluster/ingress-nginx/ingress-nginx.yaml
+++ b/ingress/single-cluster/ingress-nginx/ingress-nginx.yaml
@@ -1,0 +1,70 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion:  networking.k8s.io/v1beta1 
+kind: Ingress
+metadata:
+  name: foo-external
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+  - host: foo.example.com
+    http:
+      paths:
+      - path: "/foo"
+        backend:
+          serviceName: foo
+          servicePort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+spec:
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: http 
+  selector:
+    app: foo
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: foo
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: whereami
+        image: gcr.io/google-samples/whereami:v1.0.1 
+        ports:
+          - name: http
+            containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP


### PR DESCRIPTION
Adding Recipe for basic ingress with with an NGNIX controller. In order to keep this simple, some optional steps (like installing a certification manager) have been omitted. 

resolves #15 
