### PR TITLE
Change container image registry for grpc healthcheck

### DIFF
--- a/gateway/grpc/fe-deployment.yaml
+++ b/gateway/grpc/fe-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: hc-proxy
-        image: gcr.io/cloud-solutions-images/grpc_health_proxy:1.0.0
+        image: docker.io/salrashid123/grpc_health_proxy:1.0.0
         args: [
           "--http-listen-addr=0.0.0.0:8080",
           "--grpcaddr=localhost:50051",
@@ -54,7 +54,7 @@ spec:
           mountPath: /certs
           readOnly: true          
       - name: grpc-app
-        image: gcr.io/cloud-solutions-images/grpc_app
+        image: docker.io/salrashid123/grpc_app
         args: [
           "/grpc_server",
           "--grpcport=0.0.0.0:50051",

--- a/gateway/grpc/my-gateway.yaml
+++ b/gateway/grpc/my-gateway.yaml
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# kind: GatewayClass
-# apiVersion: networking.x-k8s.io/v1alpha1
-# metadata:
-#   name: gke-l7-rilb
-# spec:
-#   controller: networking.gke.io/gateway
-# ---
-# kind: GatewayClass
-# apiVersion: networking.x-k8s.io/v1alpha1
-# metadata:
-#   name: gke-l7-gxlb
-# spec:
-#   controller: networking.gke.io/gateway
 ---
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
@@ -46,7 +33,11 @@ spec:
     tls:      
       mode: Terminate
       options:
-        networking.gke.io/pre-shared-certs: gcp-cert-grpc-us-central 
+        networking.gke.io/pre-shared-certs: gcp-cert-grpc-us-central
+      # certificateRefs:
+      # - kind: Secret
+      #   group: ""
+      #   name: fe-secret
 ---
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
@@ -68,7 +59,11 @@ spec:
     tls:      
       mode: Terminate
       options:
-        networking.gke.io/pre-shared-certs: gcp-cert-grpc-global 
+        networking.gke.io/pre-shared-certs: gcp-cert-grpc-global
+      # certificateRefs:
+      # - kind: Secret
+      #   group: ""
+      #   name: fe-secret
 ---
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute

--- a/ingress/single-cluster/ingress-custom-grpc-health-check/README.md
+++ b/ingress/single-cluster/ingress-custom-grpc-health-check/README.md
@@ -6,7 +6,7 @@ This is a guide for how to implement proper load balancer health checking for gR
 
 The BackendConfig CRD now supports customizing HealthCheck resources. Below are the fields supported in the specification:
 
-```
+```yaml
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
@@ -42,7 +42,7 @@ Below is an example Deployment specification when using a health check proxy. Yo
     spec:
       containers:
       - name: hc-proxy
-        image: gcr.io/cloud-solutions-images/grpc_health_proxy:1.0.0
+        image: docker.io/salrashid123/grpc_health_proxy:1.0.0
         args: [
           "--http-listen-addr=0.0.0.0:8080",
           "--grpcaddr=localhost:50051",
@@ -64,6 +64,8 @@ Below is an example Deployment specification when using a health check proxy. Yo
         - containerPort: 50051        
 ```
 
+> Please note the deployments here use the health_check proxy and sample gRPC applications hosted on `docker.io/`.  You can build and deploy these images into your own repository as well.
+
 Remember that your gRPC application must implement the gRPC health protocol
 (grpc.health.v1.Health).
 
@@ -75,7 +77,7 @@ For InstanceGroup backends, the port used for the health check must be exposed i
 
 For NEG backends, exposing the health check port in the Service is not required.
 
-```
+```yaml
 type: Service
 spec:
   type: NodePort
@@ -98,7 +100,7 @@ For a full end-to-end example, see the `example/` folder.
 
 ### Non-proxied Health Check
 
-```
+```yaml
 spec:
  containers:
  - name: esp
@@ -113,7 +115,7 @@ spec:
 
 #### Service & BackendConfig
 
-```
+```yaml
 type: Service
 spec:
   type: NodePort

--- a/ingress/single-cluster/ingress-custom-grpc-health-check/example/README.md
+++ b/ingress/single-cluster/ingress-custom-grpc-health-check/example/README.md
@@ -24,6 +24,8 @@ Deploy application
 kubectl apply -f .
 ```
 
+> Please note the deployments here use the health_check proxy and sample gRPC applications hosted on `docker.io/`.  You can build and deploy these images into your own repository as well.
+
 Wait ~8mins and note down the external and ILB addresses
 
 ```bash
@@ -56,7 +58,7 @@ Verify external loadbalancing by transmitting 10 RPCs over one channel.  The res
 
 ```log
 $ docker run --add-host grpc.domain.com:$XLB_IP  \
-  -t gcr.io/cloud-solutions-images/grpc_app /grpc_client \
+  -t docker.io/salrashid123/grpc_app /grpc_client \
    --host=grpc.domain.com:443 --tlsCert /certs/CA_crt.pem \
    --servername grpc.domain.com --repeat 10 -skipHealthCheck
 
@@ -96,7 +98,7 @@ fe-deployment-6c96c9648-zj659   2/2     Running   0          4m39s
 Rerun the test.  Notice the new pods in the response 
 ```log
 $ docker run --add-host grpc.domain.com:$XLB_IP \
-   -t gcr.io/cloud-solutions-images/grpc_app /grpc_client \
+   -t docker.io/salrashid123/grpc_app /grpc_client \
    --host=grpc.domain.com:443 --tlsCert /certs/CA_crt.pem  \
    --servername grpc.domain.com --repeat 10 -skipHealthCheck
 
@@ -118,7 +120,7 @@ To test the internal loadbalancer, you must configure a VM from within an [alloc
 
 ```log
  $ docker run --add-host grpc.domain.com:$XLB_IP \
-     -t gcr.io/cloud-solutions-images/grpc_app /grpc_client \
+     -t docker.io/salrashid123/grpc_app /grpc_client \
      --host=grpc.domain.com:443 --tlsCert /certs/CA_crt.pem  \
      --servername grpc.domain.com --repeat 10 -skipHealthCheck
 
@@ -159,7 +161,7 @@ type: Opaque
     spec:
       containers:
       - name: hc-proxy
-        image: gcr.io/cloud-solutions-images/grpc_health_proxy:1.0.0
+        image: docker.io/salrashid123/grpc_health_proxy:1.0.0
         args: [
           "--http-listen-addr=0.0.0.0:8443",
           "--grpcaddr=localhost:50051",
@@ -185,7 +187,7 @@ type: Opaque
           secretName: hc-secret          
 ```
 
-You will also need to configure the service to use HTTP/2:
+You will also need to configure the service to use HTTP/2,  please make sure the healthproxy listens over TLS
 
 - `fe-srv-ingress.yaml`
 
@@ -202,5 +204,5 @@ spec:
 ```
 
 Source images used in this example can be found here:
-  - [gcr.io/cloud-solutions-images/grpc_health_proxy](https://github.com/salrashid123/grpc_health_proxy)
-  - [gcr.io/cloud-solutions-images/grpc_app](https://github.com/salrashid123/grpc_health_proxy/tree/master/example)
+  - [docker.io/salrashid123/grpc_health_proxy](https://github.com/salrashid123/grpc_health_proxy)
+  - [docker.io/salrashid123/grpc_app](https://github.com/salrashid123/grpc_health_proxy/tree/master/example)

--- a/ingress/single-cluster/ingress-custom-grpc-health-check/example/fe-deployment.yaml
+++ b/ingress/single-cluster/ingress-custom-grpc-health-check/example/fe-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: hc-proxy
-        image: gcr.io/cloud-solutions-images/grpc_health_proxy:1.0.0
+        image: docker.io/salrashid123/grpc_health_proxy:1.0.0
         args: [
           "--http-listen-addr=0.0.0.0:8443",
           "--grpcaddr=localhost:50051",
@@ -48,7 +48,7 @@ spec:
           mountPath: /config
           readOnly: true       
       - name: grpc-app
-        image: gcr.io/cloud-solutions-images/grpc_app
+        image: docker.io/salrashid123/grpc_app
         args: [
           "/grpc_server",
           "--grpcport=0.0.0.0:50051",

--- a/ingress/single-cluster/ingress-custom-grpc-health-check/grpc-hc-proxy.yaml
+++ b/ingress/single-cluster/ingress-custom-grpc-health-check/grpc-hc-proxy.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: hc-proxy
-        image: docker.io/salrashid123/grpc_health_proxy
+        image: docker.io/salrashid123/grpc_health_proxy:1.0.0
         args: [
           "--http-listen-addr=localhost:8081",
           "--grpc-addr=localhost:8080",


### PR DESCRIPTION
The original container registry reference `gcr.io/cloud-solutions-images/` is not longer accessible.

This PR updates the yaml files to point to `docker.io`.  Also notes that cutomers are encouraged to generate and manage/host their own image (since `docker.io/` is rate limited.

Updates instructions for gateway to install CRDs first.