### PR TITLE
Product docs manifest folder

### DIFF
--- a/gateway/docs/README.md
+++ b/gateway/docs/README.md
@@ -1,0 +1,5 @@
+### Google Cloud Product Docs Reference Manifests
+
+The files in this folder are referenced by Google Cloud product docs. They should not be edited or removed without explicit permission from the GKE docs team. See each manifest
+to find out which product pages it is referenced by.
+

--- a/gateway/docs/site-deploy.yaml
+++ b/gateway/docs/site-deploy.yaml
@@ -1,0 +1,41 @@
+##################################################
+# Referenced by https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#shared_gateways
+##################################################
+
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: site-v1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: site
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: site
+        version: v1
+    spec:
+      containers:
+      - name: whereami
+        image: gcr.io/google-samples/whereami:v1.1.3
+        ports:
+          - containerPort: 8080
+        env:
+        - name: METADATA
+          value: "site-v1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: site-v1
+spec:
+  selector:
+    app: site
+    version: v1
+  ports:
+  - port: 8080
+    targetPort: 8080

--- a/gateway/docs/store-autoscale.yaml
+++ b/gateway/docs/store-autoscale.yaml
@@ -1,0 +1,63 @@
+##################################################
+# Referenced by https://cloud.google.com/kubernetes-engine/docs/how-to/horizontal-pod-autoscaling#autoscale-traffic
+##################################################
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store-autoscale
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: store-autoscale
+  template:
+    metadata:
+      labels:
+        app: store-autoscale
+    spec:
+      containers:
+      - name: whereami
+        image: gcr.io/google-samples/whereami:v1.2.2
+        ports:
+          - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: store-autoscale
+  annotations:
+    networking.gke.io/max-rate-per-endpoint: "10"    
+spec:
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: http 
+  selector:
+    app: store
+  type: ClusterIP
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: store-autoscale
+spec:
+  gatewayClassName: gke-l7-gxlb
+  listeners:
+  - protocol: HTTP
+    port: 80
+    routes:
+      kind: HTTPRoute
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: store-autoscale
+  labels:
+    gateway: store-autoscale
+spec:
+  rules:
+  - forwardTo:
+    - backendRef:
+        name: store-autoscale
+      port: 8080

--- a/gateway/docs/store-autoscale.yaml
+++ b/gateway/docs/store-autoscale.yaml
@@ -34,7 +34,7 @@ spec:
     targetPort: 8080
     name: http 
   selector:
-    app: store
+    app: store-autoscale
   type: ClusterIP
 ---
 kind: Gateway

--- a/gateway/docs/store-deploy.yaml
+++ b/gateway/docs/store-deploy.yaml
@@ -1,0 +1,31 @@
+##################################################
+# Referenced by https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-multi-cluster-gateways#external-gateway
+##################################################
+
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: store
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store
+  namespace: store
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: store
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: store
+        version: v1
+    spec:
+      containers:
+      - name: whereami
+        image: gcr.io/google-samples/whereami:v1.2.1
+        ports:
+          - containerPort: 8080

--- a/gateway/docs/store-traffic-deploy.yaml
+++ b/gateway/docs/store-traffic-deploy.yaml
@@ -1,0 +1,31 @@
+##################################################
+# Referenced by https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-multi-cluster-gateways#capacity-load-balancing
+##################################################
+
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: traffic-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store
+  namespace: traffic-test
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: store
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: store
+        version: v1
+    spec:
+      containers:
+      - name: whereami
+        image: gcr.io/google-samples/whereami:v1.2.2
+        ports:
+          - containerPort: 8080

--- a/gateway/docs/store-v1v2german-deploy.yaml
+++ b/gateway/docs/store-v1v2german-deploy.yaml
@@ -1,0 +1,115 @@
+##################################################
+# Referenced by https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#internal-gateway
+##################################################
+
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store-v1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: store
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: store
+        version: v1
+    spec:
+      containers:
+      - name: whereami
+        image: gcr.io/google-samples/whereami:v1.1.3
+        ports:
+          - containerPort: 8080
+        env:
+        - name: METADATA
+          value: "store-v1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: store-v1
+spec:
+  selector:
+    app: store
+    version: v1
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store-v2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: store
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: store
+        version: v2
+    spec:
+      containers:
+      - name: whereami
+        image: gcr.io/google-samples/whereami:v1.1.3
+        ports:
+          - containerPort: 8080
+        env:
+        - name: METADATA
+          value: "store-v2"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: store-v2
+spec:
+  selector:
+    app: store
+    version: v2
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store-german
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: store
+      version: german
+  template:
+    metadata:
+      labels:
+        app: store
+        version: german
+    spec:
+      containers:
+      - name: whereami
+        image: gcr.io/google-samples/whereami:v1.1.3
+        ports:
+          - containerPort: 8080
+        env:
+        - name: METADATA
+          value: "Gutentag!"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: store-german
+spec:
+  selector:
+    app: store
+    version: german
+  ports:
+  - port: 8080
+    targetPort: 8080

--- a/gateway/docs/store-west-1-service.yaml
+++ b/gateway/docs/store-west-1-service.yaml
@@ -1,0 +1,73 @@
+##################################################
+# Referenced by https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-multi-cluster-gateways#blue-green
+##################################################
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: store
+  namespace: store
+spec:
+  selector:
+    app: store
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+kind: ServiceExport
+apiVersion: net.gke.io/v1
+metadata:
+  name: store
+  namespace: store
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: store-west-1
+  namespace: store
+spec:
+  selector:
+    app: store
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+kind: ServiceExport
+apiVersion: net.gke.io/v1
+metadata:
+  name: store-west-1
+  namespace: storeapiVersion: v1
+kind: Service
+metadata:
+  name: store
+  namespace: store
+spec:
+  selector:
+    app: store
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+kind: ServiceExport
+apiVersion: net.gke.io/v1
+metadata:
+  name: store
+  namespace: store
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: store-west-1
+  namespace: store
+spec:
+  selector:
+    app: store
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+kind: ServiceExport
+apiVersion: net.gke.io/v1
+metadata:
+  name: store-west-1
+  namespace: store

--- a/gateway/docs/store-west-2-service.yaml
+++ b/gateway/docs/store-west-2-service.yaml
@@ -1,0 +1,39 @@
+##################################################
+# Referenced by https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-multi-cluster-gateways#blue-green
+##################################################
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: store
+  namespace: store
+spec:
+  selector:
+    app: store
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+kind: ServiceExport
+apiVersion: net.gke.io/v1
+metadata:
+  name: store
+  namespace: store
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: store-west-2
+  namespace: store
+spec:
+  selector:
+    app: store
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+kind: ServiceExport
+apiVersion: net.gke.io/v1
+metadata:
+  name: store-west-2
+  namespace: store


### PR DESCRIPTION
@boredabdel I am centralizing reference manifests that the docs use into specific folders. Right now there are some docs references in https://github.com/GoogleCloudPlatform/gke-networking-recipes/tree/master/gateway/gke-gateway-controller but there are some extra manifests in there that aren't needed and I'd like to get rid of the junk. This will entail the following:

1) Merge this /docs folder
2) Each manifest has a reference back to the docs page that references it. This ensures that any changes in the docs or vice-versa are made considering both so they are not out of alignment.
3) Once I have updated the product docs to point to these manifests in the /docs folder we can remove /gateway/gke-gateway-controller folder

lmk if that makes sense to you!