### PR TITLE
Update example to support v1alpha2 schema 

### DIFF
--- a/gateway/docs/store-autoscale.yaml
+++ b/gateway/docs/store-autoscale.yaml
@@ -38,25 +38,26 @@ spec:
   type: ClusterIP
 ---
 kind: Gateway
-apiVersion: networking.x-k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 metadata:
   name: store-autoscale
 spec:
   gatewayClassName: gke-l7-gxlb
   listeners:
-  - protocol: HTTP
+  - name: http
+    protocol: HTTP
     port: 80
-    routes:
-      kind: HTTPRoute
 ---
 kind: HTTPRoute
-apiVersion: networking.x-k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 metadata:
   name: store-autoscale
   labels:
     gateway: store-autoscale
 spec:
+  parentRefs:
+  - name: store-autoscale
   rules:
-  - forwardTo:
-    - serviceName: store-autoscale
+  - backendRefs:
+    - name: store-autoscale
       port: 8080


### PR DESCRIPTION
The example references the v0.4.3 CRD which uses the v1alpha2 schema.  Update the example to conform to this schema.