### PR TITLE
Remove mention of max-rate-per-endpoint.

### DIFF
--- a/gateway/docs/store-autoscale.yaml
+++ b/gateway/docs/store-autoscale.yaml
@@ -26,8 +26,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: store-autoscale
-  annotations:
-    networking.gke.io/max-rate-per-endpoint: "10"    
 spec:
   ports:
   - port: 8080


### PR DESCRIPTION
This preview feature will be replaced by a different mechanism.