### PR TITLE
Fixing some issues with multi-cluster and unifiying some stuff across the recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ asm/
 .crt
 .key
 .pem
+certs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 asm/
 .vscode/
 .crt
-.ket
+.key
+.pem

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 asm/
 .vscode/
+.crt
+.ket

--- a/cluster-setup.md
+++ b/cluster-setup.md
@@ -8,7 +8,7 @@ This will be referenced in upcoming command line examples.
 
 ## Enable the Kubernetes Engine API for your GCP project
 
-  ```sh
+  ```bash
   gcloud services enable container.googleapis.com
   ```
 
@@ -31,7 +31,7 @@ The multi-cluster examples use the following GKE setup for deploying the manifes
 
     Note: ```machine-type=e2-standard-4``` and ```num-nodes=4``` are used to support Anthos Service Mesh (ASM) deployment. You can use smaller machine-type and less number of nodes if ASM is not required. For more information about ASM minumum requirements for GKE, please [click here](https://cloud.google.com/service-mesh/v1.7/docs/scripted-install/gke-asm-onboard-1-7#requirements).
 
-    ```sh
+    ```bash
     gcloud container clusters create gke-1 \
     --machine-type=e2-standard-4 \
     --num-nodes=4 \
@@ -53,13 +53,13 @@ The multi-cluster examples use the following GKE setup for deploying the manifes
 
 2. Ensure that the cluster is running:
 
-    ```sh
+    ```bash
     gcloud container clusters list
     ```
 
-    The output is similar to the following:
+    The output is similar to the following, your regions might be different than the ones below:
 
-    ```sh
+    ```bash
     NAME   LOCATION       MASTER_VERSION   MASTER_IP      MACHINE_TYPE   NODE_VERSION     NUM_NODES  STATUS
     gke-1  us-central1-a  1.21.5-gke.1802  34.136.74.24   e2-standard-4  1.21.5-gke.1802  4          RUNNING
     gke-2  us-west1-b     1.21.5-gke.1802  35.233.255.33  e2-standard-4  1.21.5-gke.1802  4          RUNNING
@@ -94,7 +94,7 @@ The multi-cluster examples use the following GKE setup for deploying the manifes
 
 6. [Register](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-for-anthos-setup#registering_your_clusters) your two clusters (`gke-1` and `gke-2`).
 
-    There are a few steps to complete as part of the registration process. A quick hint to get you going is the `gke-uri` for your GKE clusters.
+    There are a few steps to complete as part of the registration process.
 
     Register the clusters with Hub.
 

--- a/ingress/multi-cluster/mci-asm-https-e2e/README.md
+++ b/ingress/multi-cluster/mci-asm-https-e2e/README.md
@@ -52,8 +52,8 @@ The MCI below describes the desired traffic matching and routing behavior. Simil
 
 The MCI below also defines via annotations:
 
-- ```networking.gke.io/pre-shared-certs: "mci-certs"``` refers to [Google-Managed Certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/multi-cluster-ingress#google-managed_certificates) that was provisioned
-- ```networking.gke.io/static-ip: x.x.x.x``` refers to public [Static IP](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address) used to provision Google-Managed Certificates
+- `networking.gke.io/pre-shared-certs: "mci-certs"` refers to [Google-Managed Certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/multi-cluster-ingress#google-managed_certificates) that was provisioned
+- `networking.gke.io/static-ip: x.x.x.x` refers to public [Static IP](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address) used to provision Google-Managed Certificates
 
 ```yaml
 apiVersion: networking.gke.io/v1
@@ -91,8 +91,8 @@ If more clusters are added to the Hub, then any Pods in those clusters that matc
 
 The MCS below also defines via annotations:
 
-- ```beta.cloud.google.com/backend-config: '{"default":"ingress-backendconfig"}'``` refers to the name of a custom resource called BackendConfig. The Ingress controller uses BackendConfig to set parameters on the Google Cloud BackendService resource.
-- ```cloud.google.com/app-protocols: '{"https":"HTTPS"}'``` directs the GFE to connect to the service mesh's ingress gateway using HTTPS with TLS as described in [Ingress for External HTTP(S) Load Balancing](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb#https_tls_between_load_balancer_and_your_application) and [External HTTP(S) Load Balancing overview](https://cloud.google.com/load-balancing/docs/https#protocol_to_the_backends), for an additional layer of encryption.  
+- `beta.cloud.google.com/backend-config: '{"default":"ingress-backendconfig"}'` refers to the name of a custom resource called BackendConfig. The Ingress controller uses BackendConfig to set parameters on the Google Cloud BackendService resource.
+- `cloud.google.com/app-protocols: '{"https":"HTTPS"}'` directs the GFE to connect to the service mesh's ingress gateway using HTTPS with TLS as described in [Ingress for External HTTP(S) Load Balancing](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb#https_tls_between_load_balancer_and_your_application) and [External HTTP(S) Load Balancing overview](https://cloud.google.com/load-balancing/docs/https#protocol_to_the_backends), for an additional layer of encryption.  
 
 ```yaml
 apiVersion: networking.gke.io/v1
@@ -263,7 +263,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     gcloud config set project $PROJECT
     ```
 
-    NB: This tutorial uses Zonal Clusters, you can also use Regional Clusters. Replace a Zone with a region and use the ```--region``` flag instead of ```--zone``` in the next steps
+    NB: This tutorial uses Zonal Clusters, you can also use Regional Clusters. Replace a Zone with a region and use the `--region` flag instead of `--zone` in the next steps
 
 3. Deploy the two clusters `gke-1` and `gke-2` as specified in [cluster setup](../../../cluster-setup.md#multi-cluster-environment-basic). Once done, come back to the next step:
 
@@ -308,7 +308,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     deployment.apps/canonical-service-controller-manager condition met    
     ```
 
-6. Create a dedicated ```asm-ingress``` namespace:
+6. Create a dedicated `asm-ingress` namespace:
 
     ```bash
     kubectl --context=gke-1 create namespace asm-ingress
@@ -316,7 +316,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     kubectl --context=gke-2 create namespace asm-ingress
     ```
 
-7. Annotate the ```asm-ingress``` namespace with the ASM revision label:
+7. Annotate the `asm-ingress` namespace with the ASM revision label:
 
     ```bash
     export ASM_REVISION=$(kubectl --context=gke-1 get deploy -n istio-system \
@@ -338,7 +338,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     namespace/asm-ingress labeled
     ```
 
-8. Deploy ```ingress-deployment.yaml``` in your cluster to create the Deployment resource for Ingress Gateway:
+8. Deploy `ingress-deployment.yaml` in your cluster to create the Deployment resource for Ingress Gateway:
 
     ```bash
     kubectl --context=gke-1 apply -f ingress-deployment.yaml
@@ -384,9 +384,9 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     echo $GCLB_IP
     ```
 
-12. Edit the dns-spec.yaml file and update ```$PROJECT-ID``` value with your project id and ```$GCLB_IP``` with public IP that was created to create Endpoints.
+12. Edit the dns-spec.yaml file and update `$PROJECT-ID` value with your project id and `$GCLB_IP` with public IP that was created to create Endpoints.
 
-13. Deploy the ```dns-spec.yaml``` file in your Cloud project:  
+13. Deploy the `dns-spec.yaml` file in your Cloud project:  
     The YAML specification defines the public DNS record in the form of foo.endpoints.PROJECT-ID.cloud.goog, where PROJECT-ID is your unique project number.
 
     ```bash
@@ -406,7 +406,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     gcloud compute ssl-certificates list
     ```
 
-    The ```MANAGED_STATUS``` will indicate ```PROVISIONNING```. This is normal, the certificates will be provisionned when you deploy the MCI.
+    The `MANAGED_STATUS` will indicate `PROVISIONNING` This is normal, the certificates will be provisionned when you deploy the MCI.
 
 15. Create the private key and certificate using openssl. It will enable MCI to establish a TLS connection to the service mesh's ingress gateway:
 
@@ -418,7 +418,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     -out certs/foo.endpoints.${PROJECT}.cloud.goog.crt
     ```
 
-16. Create the Secret in the ```asm-ingress``` namespace in both clusters:
+16. Create the Secret in the `asm-ingress` namespace in both clusters:
 
     ```bash
     kubectl --context=gke-1 -n asm-ingress create secret tls edge2mesh-credential \
@@ -430,7 +430,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     --cert=certs/foo.endpoints.${PROJECT}.cloud.goog.crt
     ```
 
-17. Deploy ```ingress-gateway.yaml``` in your cluster to create the service mesh's Gateway:  
+17. Deploy `ingress-gateway.yaml` in your cluster to create the service mesh's Gateway:  
 
     ```bash
     kubectl --context=gke-1 apply -f ingress-gateway.yaml
@@ -438,7 +438,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     kubectl --context=gke-2 apply -f ingress-gateway.yaml
     ```
 
-18. Install sample application by deploying ```app.yaml``` manifest:
+18. Install sample application by deploying `app.yaml` manifest:
 
     ```bash
     kubectl --context=gke-1 apply -f app.yaml
@@ -453,9 +453,9 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     service/foo created
     ```
 
-19. Edit the ```istio-service.yaml``` file and update ```$PROJECT-ID``` value with your project id:
+19. Edit the `istio-service.yaml` file and update `$PROJECT-ID` value with your project id:
 
-20. Create service mesh's ```VirtualService``` by deploying ```istio-service.yaml``` manifest:
+20. Create service mesh's `VirtualService` by deploying `istio-service.yaml` manifest:
 
     ```bash
     kubectl --context=gke-1 apply -f istio-service.yaml
@@ -469,15 +469,15 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     virtualservice.networking.istio.io/foo-ingress created
     ```
 
-21. Edit ```mci-mcs.yaml``` file and update ```x.x.x.x``` with your IP address and ```$PROJECT-ID``` with your project id.
+21. Edit `mci-mcs.yaml` file and update `x.x.x.x` with your IP address and `$PROJECT-ID` with your project id.
 
-22. Deploy ```mci-mcs.yaml``` to create ```MultiClusterIngress```, ```MultiClusterService``` and ```BackendConfig```:
+22. Deploy `mci-mcs.yaml` to create `MultiClusterIngress` `MultiClusterService` and `BackendConfig`
 
     ```bash
     kubectl --context=gke-1 apply -f mci-mcs.yaml
     ```
 
-23. Inspect the ```MultiClusterIngress``` resource:
+23. Inspect the `MultiClusterIngress` resource:
 
     ```bash
     kubectl --context=gke-1 describe mcs mcs-service -n asm-ingress
@@ -552,7 +552,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     Normal  SYNC    31s   multi-cluster-ingress-controller  Derived Service was ensured in cluster {us-central1-a/gke-1 gke-1}
     ```
 
-24. Inspect the ```MultiClusterService``` resource to check the progress of the load balancer deployment:
+24. Inspect the `MultiClusterService` resource to check the progress of the load balancer deployment:
 
     ```bash
     kubectl --context=gke-1 describe mci gke-ingress -n asm-ingress
@@ -667,7 +667,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
 25. Use curl with the -v for verbose to reach the load balancer.
 
     ```bash
-    Note: You might get an ```ERR_SSL_VERSION_OR_CIPHER_MISMATCH``` error. This error occurs when certificates have not yet propagated to all of the Google Front Ends (GFEs) globally. Wait a few minutes, and then try again.
+    Note: You might get an `ERR_SSL_VERSION_OR_CIPHER_MISMATCH` error. This error occurs when certificates have not yet propagated to all of the Google Front Ends (GFEs) globally. Wait a few minutes, and then try again.
     ```
 
     ```bash
@@ -772,7 +772,7 @@ Now that you have the background knowledge and understanding of MCI and ASM, you
     * Connection #0 to host foo.endpoints.PROJECT_ID.cloud.goog left intact
     ```
 
-The output is very verbose when we add the follow environement variable to the ```whereami``` sample app:
+The output is very verbose when we add the follow environement variable to the `whereami` sample app:
 
   ```bash
   - name: ECHO_HEADERS

--- a/ingress/multi-cluster/mci-asm-https-e2e/app.yaml
+++ b/ingress/multi-cluster/mci-asm-https-e2e/app.yaml
@@ -20,6 +20,8 @@ spec:
         env:
         - name: METADATA
           value: "foo"
+        - name: ECHO_HEADERS
+          value: "True"
         ports:
           - name: http
             containerPort: 8080

--- a/ingress/multi-cluster/mci-basic/README.md
+++ b/ingress/multi-cluster/mci-basic/README.md
@@ -127,11 +127,11 @@ Now that you have the background knowledge and understanding of MCI, you can try
 
 3. Deploy the two clusters `gke-1` and `gke-2` as specified in [cluster setup](../../../cluster-setup.md#Multi-cluster-environment-basic) and follow the steps for cluster registration with Hub and enablement of Multi-cluster Ingress.
 
-There are two manifests in this folder:
+   There are two manifests in this folder:
     - app.yaml is the manifest for the foo and bar Deployments. This manifest should be deployed on both clusters.
     - ingress.yaml is the manifest for the MultiClusterIngress and MultiClusterService resources. These will be deployed only on the `gke-1` cluster as this was set as the config cluster and is the  cluster that the MCI controlller is listening to for updates.
 
-1. Separately log in to each cluster and deploy the app.yaml manifest. You can configure these contexts as shown [here](../../../cluster-setup.md).
+4. Separately log in to each cluster and deploy the app.yaml manifest. You can configure these contexts as shown [here](../../../cluster-setup.md).
 
     ```bash
     $ kubectl --context=gke-1 apply -f app.yaml
@@ -147,7 +147,7 @@ There are two manifests in this folder:
     deployment.apps/default-backend created
     ```
 
-2. Check workloads are deployed and running in both clusters
+5. Check workloads are deployed and running in both clusters
 
     ```bash
     $ kubectl --context=gke-2 get deploy -n multi-cluster-demo
@@ -163,7 +163,7 @@ There are two manifests in this folder:
     foo               2/2     2            2           44m
     ```
 
-3. Now log into `gke-1` and deploy the ingress.yaml manifest.
+6. Now log into `gke-1` and deploy the ingress.yaml manifest.
 
     ```bash
     $ kubectl --context=gke-1 apply -f ingress.yaml
@@ -174,7 +174,7 @@ There are two manifests in this folder:
     backendconfig.cloud.google.com/backend-health-check created
     ```
 
-4. It can take up to 10 minutes for the load balancer to deploy fully. Inspect the MCI resource to watch for events that indicate how the deployment is going. Then capture the IP address for the MCI ingress resource.
+7. It can take up to 10 minutes for the load balancer to deploy fully. Inspect the MCI resource to watch for events that indicate how the deployment is going. Then capture the IP address for the MCI ingress resource.
 
     ```bash
     $ kubectl --context=gke-1 describe mci/foobar-ingress -n multi-cluster-demo
@@ -246,7 +246,7 @@ There are two manifests in this folder:
     $ export MCI_ENDPOINT=$(kubectl --context=gke-1 get mci -n multi-cluster-demo -o yaml | grep "VIP" | awk 'END{ print $2}')
     ```
 
-5. Now use the IP address from the MCI output to reach the load balancer. Try hitting the load balancer on the different host rules to confirm that traffic is being routed correctly. We use `jq` to filter the output to make it easier to read but you could drop the `jq` portion of the command to see the full output.
+8. Now use the IP address from the MCI output to reach the load balancer. Try hitting the load balancer on the different host rules to confirm that traffic is being routed correctly. We use `jq` to filter the output to make it easier to read but you could drop the `jq` portion of the command to see the full output.
 
     ```bash
     # Hitting the default backend
@@ -268,7 +268,7 @@ There are two manifests in this folder:
     bar-5bdf58646c-rbbdn
     ```
 
-6. Now to demonstrate the health checking and failover ability of MCI, let's crash the pods in `gke-1` for one of the Services. We'll update the replicas of the `foo` Deployment to zero so that there won't be any available backends in that cluster. To confirm that traffic is not dropped, we can set a continuous curl to watch as traffic fails over. In one shell, start a continous curl against the `foo` Service.
+9. Now to demonstrate the health checking and failover ability of MCI, let's crash the pods in `gke-1` for one of the Services. We'll update the replicas of the `foo` Deployment to zero so that there won't be any available backends in that cluster. To confirm that traffic is not dropped, we can set a continuous curl to watch as traffic fails over. In one shell, start a continous curl against the `foo` Service.
 
     ```bash
     $ while true; do curl -s -H "host: foo.example.com" ${MCI_ENDPOINT} | jq -c '{cluster: .cluster_name, pod: .pod_name}'; sleep 2; done
@@ -282,7 +282,7 @@ There are two manifests in this folder:
 
     **Note:** Traffic will be load balanced to the closest cluster to the client. If you are curling from your laptop then your traffic will be directed to the closest GKE cluster to you. Whichever cluster is recieving traffic in this step will be the closest one to you so fail pods in that cluster in the next step and watch traffic failover to the other cluster.
 
-7. Open up a second shell to scale the replicas down to zero.
+10. Open up a second shell to scale the replicas down to zero.
 
     ```bash
     # Do this in the same cluster where the response came from in the previous step
@@ -294,7 +294,7 @@ There are two manifests in this folder:
     foo    0/0     0            0           63m
     ```
 
-8. Watch how traffic switches from one cluster to another as the Pods dissappear from `gke-1`. Because the `foo` Pods from both clusters are active-active backends to the load balancer, there is no traffic interuption or delay when switching over traffic from one cluster to the other. Traffic is seamllessly routed to the available backends in the other cluster.
+11. Watch how traffic switches from one cluster to another as the Pods dissappear from `gke-1`. Because the `foo` Pods from both clusters are active-active backends to the load balancer, there is no traffic interuption or delay when switching over traffic from one cluster to the other. Traffic is seamllessly routed to the available backends in the other cluster.
 
     ```bash
     ...

--- a/ingress/multi-cluster/mci-blue-green-cluster/README.md
+++ b/ingress/multi-cluster/mci-blue-green-cluster/README.md
@@ -106,7 +106,7 @@ Now that you have the background knowledge and understanding of MCI, you can try
 
 1. Download this repo and navigate to this folder
 
-    ```sh
+    ```bash
     $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
     Cloning into 'gke-networking-recipes'...
 
@@ -124,7 +124,7 @@ Now that you have the background knowledge and understanding of MCI, you can try
 
 4. Separately log in to each cluster and deploy the app.yaml manifest. You can configure these contexts as shown [here](../../cluster-setup.md).
 
-    ```sh
+    ```bash
     $ kubectl --context=gke-1 apply -f app.yaml
     namespace/multi-cluster-demo created
     deployment.apps/default-backend created
@@ -156,7 +156,7 @@ Now that you have the background knowledge and understanding of MCI, you can try
 
 6. It can take up to 10 minutes for the load balancer to deploy fully. Inspect the MCI resource to watch for events that indicate how the deployment is going. Then capture the IP address for the MCI ingress resource.
 
-    ```sh
+    ```bash
     $ kubectl --context=gke-1 describe mci/foobar-ingress -n multi-cluster-demo
     Name:         foobar-ingress
     Namespace:    multi-cluster-demo
@@ -423,7 +423,7 @@ Now that you have the background knowledge and understanding of MCI, you can try
 
 ### Cleanup
 
-```sh
+```bash
 
 kubectl --context=gke-1 delete -f app.yaml
 kubectl --context=gke-1 delete -f ingress.yaml

--- a/ingress/multi-cluster/mci-https-e2e/README.md
+++ b/ingress/multi-cluster/mci-https-e2e/README.md
@@ -35,7 +35,7 @@ This Recipes also demonstrates the following:
 - How to enable HTTPS on Multi-cluster Ingress.
 - How to use HTTPS backends with Multi-cluster Igress for end to end encryption.
 
-There are two applications in this example, ```foo``` and ```bar```. Deployed on both clusters. The External HTTPS load balancer is designed to route traffic to the closest (to the client) available backend with capacity. Traffic from clients will be load balanced to the closest backend cluster depending on the traffic matching specified in the MultiClusterIngress resource.
+There are two applications in this example, `foo` and `bar` Deployed on both clusters. The External HTTPS load balancer is designed to route traffic to the closest (to the client) available backend with capacity. Traffic from clients will be load balanced to the closest backend cluster depending on the traffic matching specified in the MultiClusterIngress resource.
 
 The two clusters in this example can be backends to MCI only if they are registered through Hub. Hub is a central registry of clusters that determines which clusters MCI can function across. A cluster must first be registered to Hub before it can be used with MCI.
 

--- a/ingress/multi-cluster/mci-https-e2e/README.md
+++ b/ingress/multi-cluster/mci-https-e2e/README.md
@@ -28,7 +28,7 @@
 
 This recipe demonstrates deploying Multi-cluster Ingress across two clusters to expose two different Services hosted across both clusters. The cluster `gke-1` is in `REGION#1` and `gke-2` is hosted in `REGION#2`, demonstrating multi-regional load balancing across clusters. All Services will share the same MultiClusterIngress and load balancer IP, but the load balancer will match traffic and send it to the right region, cluster, and Service depending on the request.
 
-[//]: # (TODO - abdelfettah@: add diagram)
+[//]: # (TODO - Missing diagram https://github.com/GoogleCloudPlatform/gke-networking-recipes/issues/119)
 
 This Recipes also demonstrates the following:
 

--- a/ingress/multi-cluster/mci-https-e2e/app.yaml
+++ b/ingress/multi-cluster/mci-https-e2e/app.yaml
@@ -16,10 +16,12 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.11
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.15
         env:
         - name: METADATA
           value: "foo"
+        - name: ECHO_HEADERS
+          value: "True"
         ports:
           - name: http
             containerPort: 8080
@@ -67,10 +69,12 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.11
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.15
         env:
         - name: METADATA
           value: "bar"
+        - name: ECHO_HEADERS
+          value: "True"
         ports:
           - name: http
             containerPort: 8080
@@ -117,7 +121,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.11
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.15
         env:
         - name: METADATA
           value: "default-backend"

--- a/ingress/multi-cluster/mci-https-e2e/dns-spec-bar.yaml
+++ b/ingress/multi-cluster/mci-https-e2e/dns-spec-bar.yaml
@@ -1,0 +1,10 @@
+swagger: "2.0"
+info:
+  description: "Cloud Endpoints DNS"
+  title: "Cloud Endpoints DNS"
+  version: "1.0.0"
+paths: {}
+host: "bar1.endpoints.$PROJECT-ID.cloud.goog"
+x-google-endpoints:
+- name: "bar1.endpoints.$PROJECT-ID.cloud.goog"
+  target: "$GCLB_IP"

--- a/ingress/multi-cluster/mci-https-e2e/dns-spec-foo.yaml
+++ b/ingress/multi-cluster/mci-https-e2e/dns-spec-foo.yaml
@@ -1,0 +1,10 @@
+swagger: "2.0"
+info:
+  description: "Cloud Endpoints DNS"
+  title: "Cloud Endpoints DNS"
+  version: "1.0.0"
+paths: {}
+host: "foo.endpoints.$PROJECT-ID.cloud.goog"
+x-google-endpoints:
+- name: "foo.endpoints.$PROJECT-ID.cloud.goog"
+  target: "$GCLB_IP"

--- a/ingress/multi-cluster/mci-https-e2e/ingress.yaml
+++ b/ingress/multi-cluster/mci-https-e2e/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: foobar-ingress
   namespace: multi-cluster-demo
   annotations:
-    networking.gke.io/static-ip: 34.149.198.76
+    networking.gke.io/static-ip: x.x.x.x
     networking.gke.io/pre-shared-certs: "mci-certs"
 spec:
   template:

--- a/ingress/multi-cluster/mci-https-e2e/ingress.yaml
+++ b/ingress/multi-cluster/mci-https-e2e/ingress.yaml
@@ -19,7 +19,7 @@ spec:
             - backend:
                 serviceName: bar
                 servicePort: 443
-      - host: foo1.endpoints.gke-net-recipes-standalone.cloud.goog
+      - host: foo1.endpoints.$PROJECT-ID.cloud.goog
         http:
           paths:
             - backend:

--- a/ingress/multi-cluster/mci-https-e2e/ingress.yaml
+++ b/ingress/multi-cluster/mci-https-e2e/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: foobar-ingress
   namespace: multi-cluster-demo
   annotations:
-    networking.gke.io/static-ip: x.x.x.x
+    networking.gke.io/static-ip: 34.149.198.76
     networking.gke.io/pre-shared-certs: "mci-certs"
 spec:
   template:
@@ -13,17 +13,17 @@ spec:
         serviceName: default-backend
         servicePort: 443
       rules:
-      - host: foo.$DOMAIN
-        http:
-          paths:
-            - backend:
-                serviceName: foo
-                servicePort: 443
-      - host: bar.$DOMAIN
+      - host: bar1.endpoints.$PROJECT-ID.cloud.goog
         http:
           paths:
             - backend:
                 serviceName: bar
+                servicePort: 443
+      - host: foo1.endpoints.gke-net-recipes-standalone.cloud.goog
+        http:
+          paths:
+            - backend:
+                serviceName: foo
                 servicePort: 443
 ---
 apiVersion: networking.gke.io/v1

--- a/ingress/single-cluster/ingress-cloudarmor/README.md
+++ b/ingress/single-cluster/ingress-cloudarmor/README.md
@@ -62,7 +62,7 @@ Steps:
    * Create `BackendConfig` in a `kube-system` namespace. Substitute example policy name with your
    CloudArmor policy name
 
-     ```sh
+     ```bash
      cat << EOF | kubectl apply -f - -n kube-system
      apiVersion: cloud.google.com/v1
      kind: BackendConfig
@@ -76,7 +76,7 @@ Steps:
 
    * Annotate `default-http-backend` service in a `kube-system` namespace with a newly created `BackendConfig`
 
-     ```sh
+     ```bash
      kubectl annotate services default-http-backend \
      beta.cloud.google.com/backend-config='{"default": "cloudarmor-test"}' -n kube-system
      ```
@@ -84,13 +84,13 @@ Steps:
 2. Replace `$POLICY_NAME` variable in `cloudarmor-ingress.yaml` file with your Google CloudArmor
 policy name.
 
-   ```sh
+   ```bash
    sed -i '.bak' 's/$POLICY_NAME/cloudarmor-test/g' cloudarmor-ingress.yaml
    ```
 
 3. Apply `cloudarmor-ingress.yaml` file
 
-   ```sh
+   ```bash
    $ kubectl apply -f cloudarmor-ingress.yaml
    ingress.networking.k8s.io/cloudarmor-test created
    backendconfig.cloud.google.com/cloudarmor-test created
@@ -107,13 +107,13 @@ policy name.
 
 1. Enable GKE API
 
-   ```sh
+   ```bash
    gcloud services enable container.googleapis.com
    ```
 
 2. Create simple zonal GKE cluster for tests
 
-   ```sh
+   ```bash
    gcloud container clusters create cluster-test \
    --zone europe-central2-a \
    --release-channel regular \
@@ -122,7 +122,7 @@ policy name.
 
 3. Configure client credentials for a new cluster
 
-   ```sh
+   ```bash
    gcloud container clusters get-credentials cluster-test \
    --zone europe-central2-a
    ````

--- a/ingress/single-cluster/ingress-custom-http-health-check/README.md
+++ b/ingress/single-cluster/ingress-custom-http-health-check/README.md
@@ -59,7 +59,7 @@ Steps:
 
 1. Apply `custom-http-hc-ingress.yaml` file
 
-   ```sh
+   ```bash
    $ kubectl apply -f custom-http-hc-ingress.yaml
      ingress.networking.k8s.io/hc-test created
      backendconfig.cloud.google.com/hc-test created
@@ -76,13 +76,13 @@ Steps:
 
 1. Enable GKE API
 
-   ```sh
+   ```bash
    gcloud services enable container.googleapis.com
    ```
 
 2. Create simple zonal GKE cluster for tests
 
-   ```sh
+   ```bash
    gcloud container clusters create cluster-test \
    --zone europe-central2-a \
    --release-channel regular \
@@ -91,7 +91,7 @@ Steps:
 
 3. Configure client credentials for a new cluster
 
-   ```sh
+   ```bash
    gcloud container clusters get-credentials cluster-test \
    --zone europe-central2-a
    ````

--- a/ingress/single-cluster/ingress-external-basic/README.md
+++ b/ingress/single-cluster/ingress-external-basic/README.md
@@ -66,7 +66,7 @@ spec:
 
 1. Download this repo and navigate to this folder
 
-```sh
+```bash
 $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
 Cloning into 'gke-networking-recipes'...
 
@@ -75,7 +75,7 @@ $ cd gke-networking-recipes/ingress/external-ingress-basic
 
 2. Deploy the Ingress, Deployment, and Service resources in the [external-ingress-basic.yaml](external-ingress-basic.yaml) manifest.
 
-```sh
+```bash
 $ kubectl apply -f external-ingress-basic.yaml
 ingress.networking.k8s.io/foo-external created
 service/foo created
@@ -119,7 +119,7 @@ Events:
 
 4. Finally, we can validate the data plane by sending traffic to our Ingress VIP.
 
-```sh
+```bash
 $ curl -H "host: foo.example.com" 34.102.236.246
 {"cluster_name":"gke-us-west","host_header":"foo.example.com","node_name":"gke-gke-us-west-default-pool-8cdbdcce-smk6.c.church-243723.internal","pod_name":"foo-55dc6d64ff-66d4w","pod_name_emoji":"👨🏽‍🏭","project_id":"church-243723","timestamp":"2020-08-05T04:00:59","zone":"us-west1-a"}
 ```
@@ -127,6 +127,6 @@ $ curl -H "host: foo.example.com" 34.102.236.246
 
 ### Cleanup
 
-```sh
+```bash
 kubectl delete -f external-ingress-basic.yaml
 ```

--- a/ingress/single-cluster/ingress-https/README.md
+++ b/ingress/single-cluster/ingress-https/README.md
@@ -96,7 +96,7 @@ With these three resources, you are capable of securing your Ingress for product
 
 1. Download this repo and navigate to this folder
 
-```sh
+```bash
 $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
 Cloning into 'gke-networking-recipes'...
 
@@ -122,7 +122,7 @@ $ gcloud compute ssl-policies create gke-ingress-ssl-policy \
 
 5. Now that all the Google Cloud resources have been created you can deploy your Kubernetes resources. Deploy the following manifest which deploys the foo and bar applications, the FrontendConfig, ManagedCertificate, and Ingress resource.
 
-```sh
+```bash
 $ kubectl apply -f secure-ingress.yaml
 ingress.networking.k8s.io/secure-ingress created
 frontendconfig.networking.gke.io/ingress-security-config created
@@ -191,7 +191,7 @@ You are now ready to serve securely on the internet!
 
 ### Cleanup
 
-```sh
+```bash
 $ kubectl delete -f secure-ingress.yaml
 $ gcloud compute addresses delete --global gke-foobar-public-ip
 $ gcloud compute ssl-policies delete gke-ingress-ssl-policy

--- a/ingress/single-cluster/ingress-iap/README.md
+++ b/ingress/single-cluster/ingress-iap/README.md
@@ -51,7 +51,7 @@ Steps:
 
 1. Reserve global static IP address for an ingress
 
-   ```sh
+   ```bash
    gcloud compute addresses create iap-test --global
    ```
 
@@ -59,7 +59,7 @@ Steps:
   
     You can use `gcloud` command to get information about reserved address.
 
-    ```sh
+    ```bash
     $ gcloud compute addresses describe iap-test --global
     address: 123.213.53.69
     addressType: EXTERNAL
@@ -69,7 +69,7 @@ Steps:
 
     Once configured, verify that your domain name resolves to the reserved IP address.
 
-    ```sh
+    ```bash
     $ nslookup -query=a iap-test.mydomain.com
     ...(output omitted)..
 
@@ -80,7 +80,7 @@ Steps:
 
 3. Create kubernetes secret with oAuth client credentials from [IAP setup prerequisite](#prerequisite-iap-setup)
 
-   ```sh
+   ```bash
    kubectl create secret generic iap-test \
    --from-literal=client_id=ATA4NDY1Mzc3NTEyMS1taMWNp1yW50LmNvbQ== \
    --from-literal=client_secret=MjgySf4zSXF1Yk5uTlAwandOc0xrRjFY
@@ -88,13 +88,13 @@ Steps:
 
 4. Replace `$DOMAIN` variable in `iap-ingress.yaml` file with your domain name
 
-   ```sh
+   ```bash
    sed -i '.bak' 's/$DOMAIN/iap-test.mydomain.com/g' iap-ingress.yaml
    ```
 
 5. Apply `iap-ingress.yaml` file
 
-   ```sh
+   ```bash
    $ kubectl apply -f iap-ingress.yaml
    ingress.networking.k8s.io/iap-test created
    managedcertificate.networking.gke.io/iap-test created
@@ -147,13 +147,13 @@ Steps:
 
 1. Authorize gcloud to access GCP
 
-   ```sh
+   ```bash
    gcloud auth login
    ```
 
 2. Configure your project
 
-   ```sh
+   ```bash
    gcloud config set project my-project
    ```
 
@@ -161,13 +161,13 @@ Steps:
 
 1. Enable GKE API
 
-   ```sh
+   ```bash
    gcloud services enable container.googleapis.com
    ```
 
 2. Create simple zonal GKE cluster for tests
 
-   ```sh
+   ```bash
    gcloud container clusters create cluster-test \
    --zone europe-central2-a \
    --release-channel regular \
@@ -176,7 +176,7 @@ Steps:
 
 3. Configure client credentials for a new cluster
 
-   ```sh
+   ```bash
    gcloud container clusters get-credentials cluster-test \
    --zone europe-central2-a
    ````

--- a/ingress/single-cluster/ingress-internal-basic/README.md
+++ b/ingress/single-cluster/ingress-internal-basic/README.md
@@ -64,7 +64,7 @@ spec:
 
 1. Download this repo and navigate to this folder
 
-```sh
+```bash
 $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
 Cloning into 'gke-networking-recipes'...
 
@@ -73,7 +73,7 @@ $ cd gke-networking-recipes/ingress/internal-ingress-basic
 
 2. Deploy the Ingress, Deployment, and Service resources in the [internal-ingress-basic.yaml](internal-ingress-basic.yaml) manifest.
 
-```sh
+```bash
 $ kubectl apply -f internal-ingress-basic.yaml
 ingress.networking.k8s.io/foo-internal created
 service/foo created
@@ -124,7 +124,7 @@ Please note in the event logs that some firewall rules should be manually config
 
 As an example, assuming you already have a Firewall Rule to allow SSH for instances with the "allow-ssh" tag:
 
-```sh
+```bash
 gcloud compute instances create l7-ilb-client \
 --image-family=debian-9 \
 --image-project=debian-cloud \
@@ -136,7 +136,7 @@ gcloud compute instances create l7-ilb-client \
 
 5. Finally, we can validate the data plane by sending traffic to our Ingress VIP from this VM we created in step 4.
 
-```sh
+```bash
 # SSH into the test VM
 $  gcloud compute ssh l7-ilb-client \
 --zone=<YOUR_ZONE>
@@ -149,12 +149,12 @@ $ curl -H "host: foo.example.com" 10.200.10.218
 
 ### Cleanup
 
-```sh
+```bash
 kubectl delete -f internal-ingress-basic.yaml
 ```
 
 Deleting the test VM created in step 4:
 
-```sh
+```bash
 gcloud compute instances delete l7-ilb-client --zone <YOUR_ZONE>
 ```

--- a/ingress/single-cluster/ingress-nginx/README.md
+++ b/ingress/single-cluster/ingress-nginx/README.md
@@ -68,7 +68,7 @@ spec:
 
 1. Download this repo and navigate to this folder
 
-```sh
+```bash
 $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
 Cloning into 'gke-networking-recipes'...
 
@@ -89,7 +89,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/cont
 
 4. Deploy the Ingress, Deployment, and Service resources in the [ingress-ngnix.yaml](ingress-ngnix.yaml) manifest.
 
-```sh
+```bash
 $ kubectl apply -f ingress-ngnix.yaml
 ingress.networking.k8s.io/ingress-resource created
 service/foo created
@@ -125,7 +125,7 @@ Please note in the event logs that some firewall rules should be manually config
 
 6. Finally, we can validate the data plane by sending traffic to our Ingress VIP
 
-```sh
+```bash
 
 $ curl -H "host: foo.example.com" 34.102.236.246 /foo
 
@@ -133,6 +133,6 @@ $ curl -H "host: foo.example.com" 34.102.236.246 /foo
 
 ### Cleanup
 
-```sh
+```bash
 kubectl delete -f ingress-ngnix.yaml
 ```

--- a/service-directory/cluster-ip-service/README.md
+++ b/service-directory/cluster-ip-service/README.md
@@ -61,7 +61,7 @@ spec:
 
 1.  Download this repo and navigate to this folder.
 
-    ```sh
+    ```bash
     $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
     Cloning into 'gke-networking-recipes'...
 
@@ -74,7 +74,7 @@ spec:
 
 1.  Enable the Service Directory feature on your fleet.
 
-    ```sh
+    ```bash
     $ gcloud alpha container hub service-directory enable
     ```
 
@@ -82,7 +82,7 @@ spec:
     ServiceDirectoryRegistrationPolicy resources in the
     [cluster-ip-service.yaml](cluster-ip-service.yaml) manifest.
 
-    ```sh
+    ```bash
     $ kubectl apply -f cluster-ip-service.yaml
     namespace/service-directory-demo created
     service/whereami created
@@ -92,7 +92,7 @@ spec:
 
 1.  Insepct the ClusterIP Service.
 
-    ```sh
+    ```bash
     $ kubectl describe services/whereami -n service-directory-demo
     Name:              whereami
     Namespace:         service-directory-demo
@@ -112,7 +112,7 @@ spec:
 1.  Validate that the service has synced to Service Directory by resolving the
     service in the region that your GKE cluster exists in.
 
-    ```sh
+    ```bash
     $ gcloud service-directory services resolve whereami --namespace=service-directory-demo --location=us-west1
     service:
       endpoints:
@@ -126,6 +126,6 @@ spec:
 
 ### Cleanup
 
-```sh
+```bash
 kubectl delete -f cluster-ip-service.yaml
 ```

--- a/service-directory/headless-service/README.md
+++ b/service-directory/headless-service/README.md
@@ -61,7 +61,7 @@ spec:
 
 1.  Download this repo and navigate to this folder.
 
-    ```sh
+    ```bash
     $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
     Cloning into 'gke-networking-recipes'...
 
@@ -74,7 +74,7 @@ spec:
 
 1.  Enable the Service Directory feature on your fleet.
 
-    ```sh
+    ```bash
     $ gcloud alpha container hub service-directory enable
     ```
 
@@ -82,7 +82,7 @@ spec:
     ServiceDirectoryRegistrationPolicy resources in the
     [headless-service.yaml](headless-service.yaml) manifest.
 
-    ```sh
+    ```bash
     $ kubectl apply -f headless-service.yaml
     namespace/service-directory-demo created
     service/whereami created
@@ -92,7 +92,7 @@ spec:
 
 1.  Insepct the headless service.
 
-    ```sh
+    ```bash
     $ kubectl describe services/whereami -n service-directory-demo
     Name:              whereami
     Namespace:         service-directory-demo
@@ -112,7 +112,7 @@ spec:
 1.  Validate that the service has synced to Service Directory by resolving the
     service in the region that your GKE cluster exists in.
 
-    ```sh
+    ```bash
     $ gcloud service-directory services resolve whereami --namespace=service-directory-demo --location=us-west1
     service:
       endpoints:
@@ -136,14 +136,14 @@ spec:
 
 1.  Scale up the deployment of the Headless Service.
 
-    ```sh
+    ```bash
     $ kubectl scale deployment.v1.apps/whereami -n service-directory-demo --replicas=5
     deployment.apps/whereami scaled
     ```
 
 1.  Inspect the deployment.
 
-    ```sh
+    ```bash
     $ kubectl describe deployment.v1.apps/whereami -n service-directory-demo
     Name:                   whereami
     Namespace:              service-directory-demo
@@ -183,7 +183,7 @@ spec:
 1.  Validate that the service has been updated in Service Directory with the new
     Pod endpoints that are running the service.
 
-    ```sh
+    ```bash
     $ gcloud service-directory services resolve whereami --namespace=service-directory-demo --location=us-west1
     service:
       endpoints:
@@ -217,6 +217,6 @@ spec:
 
 ### Cleanup
 
-```sh
+```bash
 kubectl delete -f headless-service.yaml
 ```

--- a/service-directory/internal-lb-service/README.md
+++ b/service-directory/internal-lb-service/README.md
@@ -64,7 +64,7 @@ spec:
 
 1.  Download this repo and navigate to this folder.
 
-    ```sh
+    ```bash
     $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
     Cloning into 'gke-networking-recipes'...
 
@@ -77,7 +77,7 @@ spec:
 
 1.  Enable the Service Directory feature on your fleet.
 
-    ```sh
+    ```bash
     $ gcloud alpha container hub service-directory enable
     ```
 
@@ -85,7 +85,7 @@ spec:
     ServiceDirectoryRegistrationPolicy resources in the
     [internal-lb-service.yaml](internal-lb-service.yaml) manifest.
 
-    ```sh
+    ```bash
     $ kubectl apply -f internal-lb-service.yaml
     namespace/service-directory-demo created
     service/whereami created
@@ -96,7 +96,7 @@ spec:
 1.  It can take a few minutes for the internal LoadBalancer IP of the Service
     resource to be ready. Insepct the LoadBalancer Service.
 
-    ```sh
+    ```bash
     $ kubectl describe services/whereami -n service-directory-demo
     Name:                     whereami
     Namespace:                service-directory-demo
@@ -124,7 +124,7 @@ spec:
 1.  Validate that the service has synced to Service Directory by resolving the
     service in the region that your GKE cluster exists in.
 
-    ```sh
+    ```bash
     $ gcloud service-directory services resolve whereami --namespace=service-directory-demo --location=us-west1
 
     service:
@@ -140,6 +140,6 @@ spec:
 
 ### Cleanup
 
-```sh
+```bash
 kubectl delete -f internal-lb-service.yaml
 ```

--- a/service-directory/nodeport-service/README.md
+++ b/service-directory/nodeport-service/README.md
@@ -61,7 +61,7 @@ spec:
 
 1.  Download this repo and navigate to this folder.
 
-    ```sh
+    ```bash
     $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
     Cloning into 'gke-networking-recipes'...
 
@@ -74,7 +74,7 @@ spec:
 
 1.  Enable the Service Directory feature on your fleet.
 
-    ```sh
+    ```bash
     $ gcloud alpha container hub service-directory enable
     ```
 
@@ -82,7 +82,7 @@ spec:
     ServiceDirectoryRegistrationPolicy resources in the
     [nodeport-service.yaml](nodeport-service.yaml) manifest.
 
-    ```sh
+    ```bash
     $ kubectl apply -f nodeport-service.yaml
     namespace/service-directory-demo created
     service/whereami created
@@ -92,7 +92,7 @@ spec:
 
 1.  Insepct the NodePort Service.
 
-    ```sh
+    ```bash
     $ kubectl describe services/whereami -n service-directory-demo
     Name:                     whereami
     Namespace:                service-directory-demo
@@ -115,7 +115,7 @@ spec:
 
     **Note: The cluster used in this example only had 1 node.**
 
-    ```sh
+    ```bash
     $ kubectl describe nodes
     Name:               gke-my-cluster-default-pool-0b5e50ae-1m08
     Roles:              <none>
@@ -156,7 +156,7 @@ spec:
 1.  Validate that the service has synced to Service Directory by resolving the
     service in the region that your GKE cluster exists in.
 
-    ```sh
+    ```bash
     $ gcloud service-directory services resolve whereami --namespace=service-directory-demo --location=us-west1
     service:
       endpoints:
@@ -170,6 +170,6 @@ spec:
 
 ### Cleanup
 
-```sh
+```bash
 kubectl delete -f nodeport-service.yaml
 ```

--- a/services/multi-cluster/mcs-basic/README.md
+++ b/services/multi-cluster/mcs-basic/README.md
@@ -54,7 +54,7 @@ spec:
 
 1. Download this repo and navigate to this folder
 
-    ```sh
+    ```bash
     $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
     Cloning into 'gke-networking-recipes'...
 
@@ -190,7 +190,7 @@ Now to demonstrate how MCS can be used for cluster upgrade, let's simulate migra
 
 ### Cleanup
 
-```sh
+```bash
 
 kubectl --context=gke-1 delete -f app.yaml
 kubectl --context=gke-2 delete -f app.yaml -f export.yaml

--- a/services/single-cluster/external-lb-service/README.md
+++ b/services/single-cluster/external-lb-service/README.md
@@ -44,7 +44,7 @@ spec:
 
 1. Download this repo and navigate to this folder.
 
-```sh
+```bash
 $ git clone git@github.com:GoogleCloudPlatform/gke-networking-recipes.git
 Cloning into 'gke-networking-recipes'...
 
@@ -53,7 +53,7 @@ $ cd gke-networking-recipes/services/external-lb-service
 
 2. Deploy the Deployment and Service resources in the [external-lb-service.yaml](external-lb-service.yaml) manifest.
 
-```sh
+```bash
 $ kubectl apply -f external-lb-service.yaml
 service/foo created
 deployment.apps/foo created
@@ -61,7 +61,7 @@ deployment.apps/foo created
 
 3. It may take up to a minute for the pods to deploy and up to a few minutes for the external IP address of the Service resource to be ready.  Validate their progress and make sure that no errors are surfaced in the resource events.
 
-```sh
+```bash
 $ kubectl get deploy foo
 NAME   READY   UP-TO-DATE   AVAILABLE   AGE
 foo    3/3     3            3           6m19s
@@ -91,7 +91,7 @@ Events:
 
 4. Finally, we can validate the Service is accessible from the Internet by sending traffic to the VIP address.
 
-```sh
+```bash
 $ curl -s 34.105.93.145 | jq ''
 {
   "cluster_name": "gke-1",                                                                                                                                                     
@@ -107,7 +107,7 @@ $ curl -s 34.105.93.145 | jq ''
 
 ### Cleanup
 
-```sh
+```bash
 $ kubectl delete -f external-lb-service.yaml 
 service "foo" deleted
 deployment.apps "foo" deleted

--- a/services/single-cluster/internal-lb-service/README.md
+++ b/services/single-cluster/internal-lb-service/README.md
@@ -51,7 +51,7 @@ spec:
 
 1. Download this repo and navigate to this folder.
 
-```sh
+```bash
 $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
 Cloning into 'gke-networking-recipes'...
 
@@ -60,7 +60,7 @@ $ cd gke-networking-recipes/internal-lb-service
 
 2. Deploy the Deployment and Service resources in the [internal-lb-service.yaml](internal-lb-service.yaml) manifest.
 
-```sh
+```bash
 $ kubectl apply -f internal-lb-service.yaml
 service/foo created
 deployment.apps/foo created
@@ -68,7 +68,7 @@ deployment.apps/foo created
 
 3. It may take up to a minute for the pods to deploy and up to a few minutes for the internal IP address of the Service resource to be ready. Validate the progress and make sure that no errors are surfaced in the resource events. [Google Cloud health checks](https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges) are created within your VPC by the GKE Service controller so that health checks are allowed to reach your cluster. If the load balancer health checks appear to not be passing, check that the correct VPC firewall rules are installed.
 
-```sh
+```bash
 $ kubectl get deploy foo
 NAME   READY   UP-TO-DATE   AVAILABLE   AGE
 foo    3/3     3            3           20s
@@ -103,7 +103,7 @@ Events:
 
 As an example, assuming there is already a Firewall Rule to allow SSH for instances with the "allow-ssh" tag, you can create a test VM:
 
-```sh
+```bash
 $ gcloud compute instances create l4-ilb-client \
 --image-family=debian-9 \
 --image-project=debian-cloud \
@@ -115,7 +115,7 @@ $ gcloud compute instances create l4-ilb-client \
 
 5. Finally, validate the data plane by sending traffic to the VIP from the VM created in step 4.
 
-```sh
+```bash
 # SSH into the test VM
 $  gcloud compute ssh l4-ilb-client \
 --zone=<YOUR_ZONE>
@@ -128,12 +128,12 @@ $ curl 10.138.0.31
 
 Delete the GKE internal load balancer:
 
-```sh
+```bash
 kubectl delete -f internal-lb-service.yaml
 ```
 
 and delete the test VM created in step 4:
 
-```sh
+```bash
 gcloud compute instances delete l4-ilb-client --zone <YOUR_ZONE>
 ```


### PR DESCRIPTION
- Unifying bash across all examples
- Fixing some typos
- Making the whereami spit out headers for the asm-https-e2e recipes