### PR TITLE
Fix ingress-external-basic recipe

### DIFF
--- a/ingress/single-cluster/ingress-external-basic/README.md
+++ b/ingress/single-cluster/ingress-external-basic/README.md
@@ -70,7 +70,7 @@ spec:
 $ git clone https://github.com/GoogleCloudPlatform/gke-networking-recipes.git
 Cloning into 'gke-networking-recipes'...
 
-$ cd gke-networking-recipes/ingress/external-ingress-basic
+$ cd gke-networking-recipes/ingress/single-cluster/ingress-external-basic/
 ```
 
 2. Deploy the Ingress, Deployment, and Service resources in the [external-ingress-basic.yaml](external-ingress-basic.yaml) manifest.

--- a/ingress/single-cluster/ingress-external-basic/external-ingress-basic.yaml
+++ b/ingress/single-cluster/ingress-external-basic/external-ingress-basic.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo-external
@@ -23,9 +23,13 @@ spec:
   - host: foo.example.com
     http:
       paths:
-      - backend:
-          serviceName: foo
-          servicePort: 8080
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: foo
+            port:
+              number: 8080
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
- The `networking.k8s.io/v1beta1` API versions of Ingress is no longer served as of kubernetes v1.22 ([link](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)). Updated the api version and related fields that changed.
- Fixed `cd` command in the README