### PR TITLE
bumped whereami to .19

### DIFF
--- a/archive/demo-app.yaml
+++ b/archive/demo-app.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/docs/site-deploy.yaml
+++ b/gateway/docs/site-deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/docs/store-autoscale.yaml
+++ b/gateway/docs/store-autoscale.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
 ---

--- a/gateway/docs/store-deploy.yaml
+++ b/gateway/docs/store-deploy.yaml
@@ -26,6 +26,6 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080

--- a/gateway/docs/store-traffic-deploy.yaml
+++ b/gateway/docs/store-traffic-deploy.yaml
@@ -26,6 +26,6 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080

--- a/gateway/docs/store-v1v2german-deploy.yaml
+++ b/gateway/docs/store-v1v2german-deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -95,7 +95,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/gke-gateway-controller/app/site.yaml
+++ b/gateway/gke-gateway-controller/app/site.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/gke-gateway-controller/app/store.yaml
+++ b/gateway/gke-gateway-controller/app/store.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -90,7 +90,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/gke-gateway-controller/demo-app.yaml
+++ b/gateway/gke-gateway-controller/demo-app.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/gke-gateway-controller/gateway-user-guide-app.yaml
+++ b/gateway/gke-gateway-controller/gateway-user-guide-app.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -102,7 +102,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -127,7 +127,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/gke-gateway-controller/multi-cluster-gateway/store.yaml
+++ b/gateway/gke-gateway-controller/multi-cluster-gateway/store.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
 

--- a/gateway/gke-gateway-controller/multi-tenant-demo-app.yaml
+++ b/gateway/gke-gateway-controller/multi-tenant-demo-app.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/multi-cluster/mcg-internal-basic/README.md
+++ b/gateway/multi-cluster/mcg-internal-basic/README.md
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -154,7 +154,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/multi-cluster/mcg-internal-basic/gke-1/app-v1.yaml
+++ b/gateway/multi-cluster/mcg-internal-basic/gke-1/app-v1.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/multi-cluster/mcg-internal-basic/gke-2/app-v2.yaml
+++ b/gateway/multi-cluster/mcg-internal-basic/gke-2/app-v2.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/multi-cluster/mcg-internal-blue-green/cluster-blue-app.yaml
+++ b/gateway/multi-cluster/mcg-internal-blue-green/cluster-blue-app.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/multi-cluster/mcg-internal-blue-green/cluster-green-app.yaml
+++ b/gateway/multi-cluster/mcg-internal-blue-green/cluster-green-app.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/single-cluster/global-l7-xlb-https-backend/single-cluster-global-l7-xlb-https-backend.yaml
+++ b/gateway/single-cluster/global-l7-xlb-https-backend/single-cluster-global-l7-xlb-https-backend.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "foo"
@@ -167,7 +167,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "bar"

--- a/gateway/single-cluster/global-l7-xlb/app.yaml
+++ b/gateway/single-cluster/global-l7-xlb/app.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "foo"
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "bar"

--- a/gateway/single-cluster/global-l7-xlb/single-cluster-global-l7-xlb-recipe.yaml
+++ b/gateway/single-cluster/global-l7-xlb/single-cluster-global-l7-xlb-recipe.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "foo"
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "bar"

--- a/gateway/single-cluster/regional-l7-ilb/README.md
+++ b/gateway/single-cluster/regional-l7-ilb/README.md
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -121,7 +121,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/single-cluster/regional-l7-ilb/app-v1.yaml
+++ b/gateway/single-cluster/regional-l7-ilb/app-v1.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/single-cluster/regional-l7-ilb/app-v2.yaml
+++ b/gateway/single-cluster/regional-l7-ilb/app-v2.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/gateway/single-cluster/regional-l7-ilb/single-regional-l7-ilb-recipe.yaml
+++ b/gateway/single-cluster/regional-l7-ilb/single-regional-l7-ilb-recipe.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - containerPort: 8080
         env:

--- a/ingress/multi-cluster/mci-asm-https-e2e/app.yaml
+++ b/ingress/multi-cluster/mci-asm-https-e2e/app.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "foo"

--- a/ingress/multi-cluster/mci-basic/app.yaml
+++ b/ingress/multi-cluster/mci-basic/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "foo"
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "bar"
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "default-backend"

--- a/ingress/multi-cluster/mci-blue-green-cluster/app.yaml
+++ b/ingress/multi-cluster/mci-blue-green-cluster/app.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "default-backend"
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "foo"

--- a/ingress/multi-cluster/mci-frontend-config/app.yaml
+++ b/ingress/multi-cluster/mci-frontend-config/app.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "foo"
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "bar"
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "default-backend"

--- a/ingress/single-cluster/ingress-asm-multi-backendconfig/backend-services.yaml
+++ b/ingress/single-cluster/ingress-asm-multi-backendconfig/backend-services.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "foo"
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "bar"

--- a/ingress/single-cluster/ingress-cloudarmor/cloudarmor-ingress.yaml
+++ b/ingress/single-cluster/ingress-cloudarmor/cloudarmor-ingress.yaml
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/ingress/single-cluster/ingress-custom-http-health-check/custom-http-hc-ingress.yaml
+++ b/ingress/single-cluster/ingress-custom-http-health-check/custom-http-hc-ingress.yaml
@@ -66,7 +66,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/ingress/single-cluster/ingress-external-basic/external-ingress-basic.yaml
+++ b/ingress/single-cluster/ingress-external-basic/external-ingress-basic.yaml
@@ -62,7 +62,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/ingress/single-cluster/ingress-https/secure-ingress.yaml
+++ b/ingress/single-cluster/ingress-https/secure-ingress.yaml
@@ -108,7 +108,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080
@@ -134,7 +134,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/ingress/single-cluster/ingress-iap/iap-ingress.yaml
+++ b/ingress/single-cluster/ingress-iap/iap-ingress.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/ingress/single-cluster/ingress-internal-basic/internal-ingress-basic.yaml
+++ b/ingress/single-cluster/ingress-internal-basic/internal-ingress-basic.yaml
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/ingress/single-cluster/ingress-nginx/ingress-nginx.yaml
+++ b/ingress/single-cluster/ingress-nginx/ingress-nginx.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/service-directory/cluster-ip-service/cluster-ip-service.yaml
+++ b/service-directory/cluster-ip-service/cluster-ip-service.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/service-directory/headless-service/headless-service.yaml
+++ b/service-directory/headless-service/headless-service.yaml
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/service-directory/internal-lb-service/internal-lb-service.yaml
+++ b/service-directory/internal-lb-service/internal-lb-service.yaml
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/service-directory/nodeport-service/nodeport-service.yaml
+++ b/service-directory/nodeport-service/nodeport-service.yaml
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/services/multi-cluster/mcs-basic/app.yaml
+++ b/services/multi-cluster/mcs-basic/app.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         env:
         - name: METADATA
           value: "default-backend"

--- a/services/single-cluster/external-lb-service/external-lb-service.yaml
+++ b/services/single-cluster/external-lb-service/external-lb-service.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/services/single-cluster/internal-lb-service/internal-lb-service.yaml
+++ b/services/single-cluster/internal-lb-service/internal-lb-service.yaml
@@ -45,7 +45,7 @@ spec:
     spec:
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
.19 has an important performance optimization although with a slight fix for pulling GCE metadata that bumps throughput in my texting from 4-8x.