### PR TITLE
Change networking.k8s.io/v1beta1 to networking.k8s.io/v1 for internal ingress recipe

### DIFF
--- a/ingress/single-cluster/ingress-internal-basic/internal-ingress-basic.yaml
+++ b/ingress/single-cluster/ingress-internal-basic/internal-ingress-basic.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo-internal
@@ -23,9 +23,13 @@ spec:
   - host: foo.example.com
     http:
       paths:
-      - backend:
-          serviceName: foo
-          servicePort: 8080
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: foo
+            port:
+              number: 8080
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Change networking.k8s.io/v1beta1 to networking.k8s.io/v1 since v1beta1 is no longer served as of v1.22
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingressclass-v122

Update the ingress rule path