### PR TITLE
Update apiVersion for custom-http-hc-ingress

### DIFF
--- a/ingress/single-cluster/ingress-custom-http-health-check/custom-http-hc-ingress.yaml
+++ b/ingress/single-cluster/ingress-custom-http-health-check/custom-http-hc-ingress.yaml
@@ -12,17 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hc-test
+  annotations:
+    kubernetes.io/ingress.class: "gce"
 spec:
   rules:
   - http:
       paths:
-      - backend:
-          serviceName: whereami
-          servicePort: 80
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: whereami
+            port: 
+              number: 80
 ---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig


### PR DESCRIPTION
1. Update apiVersion from networking.k8s.io/v1beta1 to networking.k8s.io.
2. Explicitly specify ingress.class annotation since it won't be automatically populated, and is useful to distinguish internal/external lb.
3. Update ingress rule paths.