### PR TITLE
Update test timeout and add wait_for_glbc_deletion for ingress resources cleanup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ test: bin/recipes-test
 	bin/recipes-test \
 		--run-in-prow=$(RUN_IN_PROW) \
 		--boskos-resource-type=$(BOSKOS_RESOURCE_TYPE) \
-		-test.v
-		-test.timeout=0
+		-test.v \
+		-test.timeout=180m
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
* Add wait_for_glbc_deletion to wait for all ingress resources cleaned up before deleting cluster.
* Update test timeout so test won't keep hanging.