### PR TITLE
Additional attempts for check_http_traffic, and update skip test message

### DIFF
--- a/test/helper.sh
+++ b/test/helper.sh
@@ -479,9 +479,9 @@ check_http_status() {
         eval_cmd="${eval_cmd} -k"
     fi
 
-    # 60*5s=5min
+    # 180*5s=15min
     local attempt
-    for attempt in $(seq 60); do
+    for attempt in $(seq 180); do
         local got_code
         got_code=$(eval ${eval_cmd} || true)
         if [[ "${got_code}" == "${expect_code}" ]]; then

--- a/test/recipe_test.go
+++ b/test/recipe_test.go
@@ -62,7 +62,8 @@ func runRecipeTest(t *testing.T, recipeDir string) {
 	for _, file := range []string{"setup.sh", "run-test.sh", "cleanup.sh"} {
 		path := path.Join(recipeDir, file)
 		if _, err := os.Stat(path); err != nil {
-			t.Skipf("Skipping test %q: stat(%q) = %v", recipeDir, path, err)
+			t.Logf("stat(%q) = %v", path, err)
+			t.Skipf("Skipping test %q: %q doesn't exist", recipeDir, path)
 		}
 		paths = append(paths, path)
 	}


### PR DESCRIPTION
* Extend check traffic wait time from 60x5s=5min to 180x5=15min since existing tests are failing due to insufficient wait time.
* Update skip test message in recipe_test.go.