### PR TITLE
Add gcpbackendpolicies CRD schema

### DIFF
--- a/gateway-api/config/servicepolicies/crd/standard/gcpbackendpolicies.yaml
+++ b/gateway-api/config/servicepolicies/crd/standard/gcpbackendpolicies.yaml
@@ -1,0 +1,280 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  creationTimestamp: null
+  name: gcpbackendpolicies.networking.gke.io
+spec:
+  conversion:
+    strategy: None
+  group: networking.gke.io
+  names:
+    kind: GCPBackendPolicy
+    listKind: GCPBackendPolicyList
+    plural: gcpbackendpolicies
+    singular: gcpbackendpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: GCPBackendPolicy provides a way to apply LoadBalancer policy
+          configuration with the GKE implementation of the Gateway API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GCPBackendPolicy.
+            properties:
+              default:
+                description: Default defines default policy configuration for the
+                  targeted resource.
+                properties:
+                  connectionDraining:
+                    description: ConnectionDraining contains configuration for connection
+                      draining
+                    properties:
+                      drainingTimeoutSec:
+                        description: DrainingTimeoutSec is a BackendService parameter.
+                          It is used during removal of VMs from instance groups. This
+                          guarantees that for the specified time all existing connections
+                          to a VM will remain untouched, but no new connections will
+                          be accepted. Set timeout to zero to disable connection draining.
+                          Enable the feature by specifying a timeout of up to one
+                          hour. If the field is omitted, a default value (0s) will
+                          be used. See https://cloud.google.com/compute/docs/reference/rest/v1/backendServices
+                        format: int64
+                        maximum: 3600
+                        minimum: 0
+                        type: integer
+                    type: object
+                  iap:
+                    description: IAP contains the configurations for Identity-Aware
+                      Proxy. Identity-Aware Proxy manages access control policies
+                      for backend services associated with a HTTPRoute, so they can
+                      be accessed only by authenticated users or applications with
+                      correct Identity and Access Management (IAM) role. See https://cloud.google.com/compute/docs/reference/rest/v1/backendServices
+                    properties:
+                      clientID:
+                        description: ClientID is the OAuth2 client ID to use for the
+                          authentication flow. See iap.oauth2ClientId in https://cloud.google.com/compute/docs/reference/rest/v1/backendServices
+                          ClientID must be set if Enabled is set to true.
+                        type: string
+                      enabled:
+                        description: Enabled denotes whether the serving infrastructure
+                          will authenticate and authorize all incoming requests. If
+                          true, the ClientID and Oauth2ClientSecret fields must be
+                          non-empty. If not specified, this defaults to false, which
+                          means Identity-Aware Proxy is disabled by default.
+                        type: boolean
+                      oauth2ClientSecret:
+                        description: Oauth2ClientSecret contains the OAuth2 client
+                          secret to use for the authentication flow. See https://cloud.google.com/compute/docs/reference/rest/v1/backendServices
+                          Oauth2ClientSecret must be set if Enabled is set to true.
+                        properties:
+                          name:
+                            description: Name is the reference to the secret resource.
+                            type: string
+                        type: object
+                    type: object
+                  logging:
+                    description: LoggingConfig contains configuration for logging.
+                    properties:
+                      enabled:
+                        description: Enabled denotes whether to enable logging for
+                          the load balancer traffic served by this backend service.
+                          If not specified, this defaults to false, which means logging
+                          is disabled by default.
+                        type: boolean
+                      sampleRate:
+                        description: This field can only be specified if logging is
+                          enabled for this backend service. The value of the field
+                          must be in range [0, 1e6]. This is converted to a floating
+                          point value in the range [0, 1] by dividing by 1e6 for use
+                          with the GCE api and interpreted as the proportion of requests
+                          that will be logged. By default all requests will be logged.
+                        format: int32
+                        maximum: 1000000
+                        minimum: 0
+                        type: integer
+                    type: object
+                  securityPolicy:
+                    description: SecurityPolicy is a reference to a GCP Cloud Armor
+                      SecurityPolicy resource.
+                    type: string
+                  sessionAffinity:
+                    description: SessionAffinityConfig contains configuration for
+                      stickiness parameters.
+                    properties:
+                      cookieTtlSec:
+                        description: CookieTTLSec specifies the lifetime of cookies
+                          in seconds. This setting requires GENERATED_COOKIE or HTTP_COOKIE
+                          session affinity. If set to 0, the cookie is non-persistent
+                          and lasts only until the end of the browser session (or
+                          equivalent). The maximum allowed value is two weeks (1,209,600).
+                        format: int64
+                        maximum: 1209600
+                        minimum: 0
+                        type: integer
+                      type:
+                        description: Type specifies the type of session affinity to
+                          use. If not specified, this defaults to NONE.
+                        enum:
+                        - CLIENT_IP
+                        - CLIENT_IP_PORT_PROTO
+                        - CLIENT_IP_PROTO
+                        - GENERATED_COOKIE
+                        - HEADER_FIELD
+                        - HTTP_COOKIE
+                        - NONE
+                        type: string
+                    type: object
+                  timeoutSec:
+                    description: TimeoutSec is a BackendService parameter. See https://cloud.google.com/compute/docs/reference/rest/v1/backendServices.
+                      If the field is omitted, a default value (30s) will be used.
+                    format: int64
+                    maximum: 2147483647
+                    minimum: 1
+                    type: integer
+                type: object
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            description: Status defines the current state of GCPBackendPolicy.
+            properties:
+              conditions:
+                description: Conditions describe the current conditions of the GCPBackendPolicy.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: GCPBackendPolicy
+    listKind: GCPBackendPolicyList
+    plural: gcpbackendpolicies
+    singular: gcpbackendpolicy
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
**Description**
This PR adds the gcpbackendpolicies.networking.gke.io since LBPolicy was replaced by it, see here: https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api#policy. 

This CRD was grabbed directly from a GKE 1.26 cluster with gateway API.