### PR TITLE
Introduce sleep after running each recipe.

### DIFF
--- a/test/recipe_test.go
+++ b/test/recipe_test.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path"
 	"testing"
+	"time"
 )
 
 var testFilePaths = []string{
@@ -49,6 +50,7 @@ func runRecipeTests(t *testing.T, parentPath string, fileNames []fs.DirEntry) {
 			}
 			runRecipeTest(t, path)
 		})
+		time.Sleep(30 * time.Second)
 	}
 }
 


### PR DESCRIPTION
* We observe issues when starting all jobs together because this can lead to a race condition with multiple writes to kube config file, since all clusters will be finished at roughly the same time.
* Thus, we introduce a sleep after each job so clusters won't all be created at the same time.

/assign @boredabdel 