### PR TITLE
fix: networking.gke.io/load-balancer-type for GKE 1.17 and later

### DIFF
--- a/services/single-cluster/internal-lb-service/internal-lb-service.yaml
+++ b/services/single-cluster/internal-lb-service/internal-lb-service.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   name: foo
   annotations:
-    cloud.google.com/load-balancer-type: "Internal"
+    networking.gke.io/load-balancer-type: "Internal"
   labels:
     app: foo
 spec:


### PR DESCRIPTION
Ref: https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer#load_balancer_types