### PR TITLE
Updated example following traffic-based autoscaling GA launch.

### DIFF
--- a/gateway/docs/store-autoscale.yaml
+++ b/gateway/docs/store-autoscale.yaml
@@ -26,16 +26,26 @@ apiVersion: v1
 kind: Service
 metadata:
   name: store-autoscale
-  annotations:
-    networking.gke.io/max-rate-per-endpoint: "10"
 spec:
   ports:
   - port: 8080
     targetPort: 8080
-    name: http 
+    name: http
   selector:
     app: store-autoscale
   type: ClusterIP
+---
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  name: store-autoscale
+spec:
+  default:
+    maxRatePerEndpoint: 10
+  targetRef:
+    group: ""
+    kind: Service
+    name: store-autoscale
 ---
 kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1beta1


### PR DESCRIPTION
Updated example to match the traffic-based workload horizontal autoscaling updated API.

The previous API (an annotation on Service) is still temporarily supported but deprecated. Users should switch to the new `maxRatePerEndpoint` field on `GCPBackendPolicy`.